### PR TITLE
bucket strings cleanup

### DIFF
--- a/src/attrs-table.cc
+++ b/src/attrs-table.cc
@@ -9,9 +9,10 @@
 static EntryToken* entryTokens[100];
 static const int MAX_BUFFER_SIZE = 16 << 10;
 
-AttributesTable::AttributesTable(StringsTable* strings_table)
+AttributesTable::AttributesTable(StringsTable* strings_table, v8::Handle<v8::Object> ignored_attributes)
         : attributes_hash_set_(),
           strings_table_(strings_table) {
+              ignored_attributes_ = ignored_attributes;
               for (int i = 0; i < 100; i++) {
                   entryTokens[i] = new EntryToken();
               }
@@ -85,9 +86,10 @@ bool AttributesTable::prepare_entry_buffer(const v8::Local<v8::Object>& pt,
     for (u_int32_t i = 0; i < length; ++i) {
         v8::Local<v8::Value> key = Nan::Get(keys, i).ToLocalChecked();
         v8::Local<v8::String> key_str(key->ToString());
-        if (bubo_utils::is_ignored_attribute(key_str)) {
+        if (!ignored_attributes_.IsEmpty() && Nan::HasOwnProperty(ignored_attributes_, key_str).FromJust()) {
             continue;
         }
+
         v8::String::Utf8Value tag(key_str);
         v8::String::Utf8Value val(Nan::Get(pt, key_str).ToLocalChecked());
 

--- a/src/attrs-table.cc
+++ b/src/attrs-table.cc
@@ -18,8 +18,7 @@ AttributesTable::AttributesTable(StringsTable* strings_table)
         }
 
 
-/* Return true if the point corresponding to the tags/tagnames is found */
-bool AttributesTable::lookup(const v8::Local<v8::Object>& pt,
+bool AttributesTable::add(const v8::Local<v8::Object>& pt,
                              v8::Local<v8::String>& attr_str, int* error) {
     int entrylen = 0;
 
@@ -30,6 +29,19 @@ bool AttributesTable::lookup(const v8::Local<v8::Object>& pt,
     }
 
     return !attributes_hash_set_.insert(entry_buf_, entrylen);
+}
+
+bool AttributesTable::contains(const v8::Local<v8::Object>& pt, int* error) {
+    int entrylen = 0;
+    v8::Local<v8::String> dummy;
+
+    prepare_entry_buffer(pt, &entrylen, false, dummy, error);
+
+    if (*error) {
+        return false;
+    }
+
+    return attributes_hash_set_.contains(entry_buf_, entrylen);
 }
 
 void AttributesTable::remove(const v8::Local<v8::Object>& pt) {

--- a/src/attrs-table.cc
+++ b/src/attrs-table.cc
@@ -19,11 +19,11 @@ AttributesTable::AttributesTable(StringsTable* strings_table, v8::Handle<v8::Obj
         }
 
 
-bool AttributesTable::add(const v8::Local<v8::Object>& pt,
+bool AttributesTable::add(const v8::Local<v8::Object>& pt, bool should_get_attr_str,
                              v8::Local<v8::String>& attr_str, int* error) {
     int entrylen = 0;
 
-    prepare_entry_buffer(pt, &entrylen, true, attr_str, error);
+    prepare_entry_buffer(pt, &entrylen, should_get_attr_str, attr_str, error);
 
     if (*error) {
         return false;

--- a/src/attrs-table.cc
+++ b/src/attrs-table.cc
@@ -9,14 +9,16 @@
 static EntryToken* entryTokens[100];
 static const int MAX_BUFFER_SIZE = 16 << 10;
 
-AttributesTable::AttributesTable(StringsTable* strings_table, v8::Handle<v8::Object> ignored_attributes)
-        : attributes_hash_set_(),
-          strings_table_(strings_table) {
-              ignored_attributes_ = ignored_attributes;
-              for (int i = 0; i < 100; i++) {
-                  entryTokens[i] = new EntryToken();
-              }
-        }
+AttributesTable::AttributesTable(StringsTable* strings_table,
+                                 Nan::Persistent<v8::Object>* ignored_attributes)
+    : attributes_hash_set_(),
+      strings_table_(strings_table),
+      ignored_attributes_(ignored_attributes)
+{
+    for (int i = 0; i < 100; i++) {
+      entryTokens[i] = new EntryToken();
+    }
+}
 
 
 bool AttributesTable::add(const v8::Local<v8::Object>& pt, bool should_get_attr_str,
@@ -86,11 +88,11 @@ bool AttributesTable::prepare_entry_buffer(const v8::Local<v8::Object>& pt,
     for (u_int32_t i = 0; i < length; ++i) {
         v8::Local<v8::Value> key = Nan::Get(keys, i).ToLocalChecked();
         v8::Local<v8::String> key_str(key->ToString());
-        if (!ignored_attributes_.IsEmpty() && Nan::HasOwnProperty(ignored_attributes_, key_str).FromJust()) {
+        if (!ignored_attributes_->IsEmpty() && Nan::HasOwnProperty(Nan::New(*ignored_attributes_), key_str).FromJust()) {
             continue;
         }
 
-        v8::String::Utf8Value tag(key_str);
+        v8::String::Utf8Value tag(key);
         v8::String::Utf8Value val(Nan::Get(pt, key_str).ToLocalChecked());
 
         EntryToken* et = entryTokens[i];

--- a/src/attrs-table.h
+++ b/src/attrs-table.h
@@ -14,7 +14,8 @@ public:
 	AttributesTable(StringsTable* strings_table);
     virtual ~AttributesTable();
 
-    bool lookup(const v8::Local<v8::Object>& pt, v8::Local<v8::String>& attr_str, int* error);
+	bool add(const v8::Local<v8::Object>& pt, v8::Local<v8::String>& attr_str, int* error);
+	bool contains(const v8::Local<v8::Object>& pt, int* error);
     void remove(const v8::Local<v8::Object>& pt);
     void stats(v8::Local<v8::Object>& stats) const;
 

--- a/src/attrs-table.h
+++ b/src/attrs-table.h
@@ -11,7 +11,7 @@ class StringsTable;
 
 class AttributesTable {
 public:
-	AttributesTable(StringsTable* strings_table, v8::Handle<v8::Object> ignored_attributes);
+	AttributesTable(StringsTable* strings_table, Nan::Persistent<v8::Object>* ignored_attributes);
     virtual ~AttributesTable();
 
 	bool add(const v8::Local<v8::Object>& pt, bool should_get_attr_str, v8::Local<v8::String>& attr_str, int* error);
@@ -51,7 +51,7 @@ public:
 protected:
 	BuboHashSet<BytePtrHash, BytePtrEqual> attributes_hash_set_;
 	StringsTable* strings_table_;
-	v8::Handle<v8::Object> ignored_attributes_;
+	Nan::Persistent<v8::Object>* ignored_attributes_;
 
 	BYTE entry_buf_[16 << 10] __attribute__ ((aligned (8)));
 };

--- a/src/attrs-table.h
+++ b/src/attrs-table.h
@@ -14,7 +14,7 @@ public:
 	AttributesTable(StringsTable* strings_table, v8::Handle<v8::Object> ignored_attributes);
     virtual ~AttributesTable();
 
-	bool add(const v8::Local<v8::Object>& pt, v8::Local<v8::String>& attr_str, int* error);
+	bool add(const v8::Local<v8::Object>& pt, bool should_get_attr_str, v8::Local<v8::String>& attr_str, int* error);
 	bool contains(const v8::Local<v8::Object>& pt, int* error);
     void remove(const v8::Local<v8::Object>& pt);
     void stats(v8::Local<v8::Object>& stats) const;

--- a/src/attrs-table.h
+++ b/src/attrs-table.h
@@ -11,7 +11,7 @@ class StringsTable;
 
 class AttributesTable {
 public:
-	AttributesTable(StringsTable* strings_table);
+	AttributesTable(StringsTable* strings_table, v8::Handle<v8::Object> ignored_attributes);
     virtual ~AttributesTable();
 
 	bool add(const v8::Local<v8::Object>& pt, v8::Local<v8::String>& attr_str, int* error);
@@ -32,7 +32,7 @@ public:
      * Optionally, one can ask for the attr_str to be filled in with the tags and tag_names.
      *
      * @pt: The javascript object whose tag/val members are added to the entry buffer.
-     *      (note: Certain attributes are ignored (based on bubo_utils::is_ignored_attribute()))
+     *      (note: Certain attributes may be ignored)
      * @entry_len: length of the buffer being prepared in bytes
      * @get_attr_str: boolean specifying whether we want attr_str to be filled in.
      * @attr_str: optional v8::String reference to be filled with 'tag1=tagname1,tag2=tagname2,..'
@@ -51,6 +51,7 @@ public:
 protected:
 	BuboHashSet<BytePtrHash, BytePtrEqual> attributes_hash_set_;
 	StringsTable* strings_table_;
+	v8::Handle<v8::Object> ignored_attributes_;
 
 	BYTE entry_buf_[16 << 10] __attribute__ ((aligned (8)));
 };

--- a/src/bubo-cache.cc
+++ b/src/bubo-cache.cc
@@ -5,8 +5,8 @@
 #include "attrs-table.h"
 #include "persistent-string.h"
 
-std::string stdString(const v8::Local<v8::String>& spaceBucket) {
-    const v8::String::Utf8Value s(spaceBucket);
+std::string stdString(const v8::Local<v8::String>& bucket) {
+    const v8::String::Utf8Value s(bucket);
     return std::string(*s);
 }
 
@@ -24,11 +24,11 @@ BuboCache::~BuboCache() {
 }
 
 
-bool BuboCache::lookup(const v8::Local<v8::String>& spaceBucket,
+bool BuboCache::lookup(const v8::Local<v8::String>& bucket,
                        const v8::Local<v8::Object>& pt,
                        v8::Local<v8::String>& attr_str,
                        int* error) {
-    std::string key = stdString(spaceBucket);
+    std::string key = stdString(bucket);
     AttributesTable* at = NULL;
     bubo_cache_t::iterator it = bubo_cache_.find(key);
     if (it == bubo_cache_.end()) {
@@ -41,9 +41,9 @@ bool BuboCache::lookup(const v8::Local<v8::String>& spaceBucket,
 }
 
 
-void BuboCache::remove(const v8::Local<v8::String>& spaceBucket,
+void BuboCache::remove(const v8::Local<v8::String>& bucket,
                        const v8::Local<v8::Object>& pt) {
-    std::string key = stdString(spaceBucket);
+    std::string key = stdString(bucket);
 
     bubo_cache_t::iterator it = bubo_cache_.find(key);
     if (it != bubo_cache_.end()) {
@@ -51,27 +51,27 @@ void BuboCache::remove(const v8::Local<v8::String>& spaceBucket,
     }
 }
 
-long extractDay(const char* spaceBucket);
-char* extractSpace(const char* spaceBucket);
+long extractDay(const char* bucket);
+char* extractSpace(const char* bucket);
 
-long extractDay(const char* spaceBucket) {
-    const char* p = spaceBucket;
+long extractDay(const char* bucket) {
+    const char* p = bucket;
     while(*(p++) != '@');
     return strtol(p, NULL, 10);
 }
 
-int spaceLength(const char* spaceBucket) {
+int spaceLength(const char* bucket) {
     int i = 0;
-    while (spaceBucket[i] != '@') {
+    while (bucket[i] != '@') {
         i++;
     }
     return i;
 }
 
-void BuboCache::remove_bucket(const v8::Local<v8::String>& spaceBucket) {
+void BuboCache::remove_bucket(const v8::Local<v8::String>& bucket) {
     // Note that the bucket is always a numeric value.
     // We remove all buckets with numeric value less than or equal to the requested bucket.
-    const v8::String::Utf8Value s(spaceBucket);
+    const v8::String::Utf8Value s(bucket);
     const char* deleteSpace = *s;
     int length = spaceLength(deleteSpace);
     long deleteBucket = extractDay(deleteSpace);

--- a/src/bubo-cache.cc
+++ b/src/bubo-cache.cc
@@ -5,9 +5,9 @@
 #include "attrs-table.h"
 #include "persistent-string.h"
 
-BuboCache::Bucket::Bucket(const v8::Local<v8::String>& spaceBucket) {
+std::string stdString(const v8::Local<v8::String>& spaceBucket) {
     const v8::String::Utf8Value s(spaceBucket);
-    spaceBucket_ = std::string(*s);
+    return std::string(*s);
 }
 
 BuboCache::BuboCache()
@@ -28,7 +28,7 @@ bool BuboCache::lookup(const v8::Local<v8::String>& spaceBucket,
                        const v8::Local<v8::Object>& pt,
                        v8::Local<v8::String>& attr_str,
                        int* error) {
-    Bucket key(spaceBucket);
+    std::string key = stdString(spaceBucket);
     AttributesTable* at = NULL;
     bubo_cache_t::iterator it = bubo_cache_.find(key);
     if (it == bubo_cache_.end()) {
@@ -43,7 +43,7 @@ bool BuboCache::lookup(const v8::Local<v8::String>& spaceBucket,
 
 void BuboCache::remove(const v8::Local<v8::String>& spaceBucket,
                        const v8::Local<v8::Object>& pt) {
-    Bucket key(spaceBucket);
+    std::string key = stdString(spaceBucket);
 
     bubo_cache_t::iterator it = bubo_cache_.find(key);
     if (it != bubo_cache_.end()) {
@@ -77,7 +77,7 @@ void BuboCache::remove_bucket(const v8::Local<v8::String>& spaceBucket) {
     long deleteBucket = extractDay(deleteSpace);
 
     for (bubo_cache_t::iterator it = bubo_cache_.begin(); it != bubo_cache_.end(); ) {
-        const char* storedString = it->first.spaceBucket_.c_str();
+        const char* storedString = it->first.c_str();
 
         if (!strncmp(deleteSpace, storedString, length)) {
             long storedBucket = extractDay(storedString);
@@ -107,6 +107,6 @@ void BuboCache::stats(v8::Local<v8::Object>& stats) const {
         v8::Local<v8::Object> attr_stats = Nan::New<v8::Object>();
 
         it->second->stats(attr_stats);
-        Nan::Set(stats, Nan::New(it->first.spaceBucket_.c_str()).ToLocalChecked(), attr_stats);
+        Nan::Set(stats, Nan::New(it->first.c_str()).ToLocalChecked(), attr_stats);
     }
 }

--- a/src/bubo-cache.cc
+++ b/src/bubo-cache.cc
@@ -23,6 +23,9 @@ BuboCache::~BuboCache() {
     delete strings_table_;
 }
 
+void BuboCache::initialize(v8::Local<v8::Object> ignoredAttrs) {
+    ignored_attributes_.Reset(ignoredAttrs);
+}
 
 bool BuboCache::add(const v8::Local<v8::String>& bucket,
                        const v8::Local<v8::Object>& pt,
@@ -32,7 +35,7 @@ bool BuboCache::add(const v8::Local<v8::String>& bucket,
     AttributesTable* at = NULL;
     bubo_cache_t::iterator it = bubo_cache_.find(key);
     if (it == bubo_cache_.end()) {
-        at = new AttributesTable(strings_table_);
+        at = new AttributesTable(strings_table_, Nan::New(ignored_attributes_));
         bubo_cache_.insert(std::make_pair(key, at));
     } else {
         at = it->second;

--- a/src/bubo-cache.cc
+++ b/src/bubo-cache.cc
@@ -70,6 +70,19 @@ void BuboCache::delete_bucket(const v8::Local<v8::String>& bucket) {
     bubo_cache_.erase(str);
 }
 
+v8::Local<v8::Array> BuboCache::get_buckets() {
+    v8::Local<v8::Array> keys = v8::Array::New();
+    int k = 0;
+
+    for(bubo_cache_t::iterator it = bubo_cache_.begin(); it != bubo_cache_.end(); ++it) {
+        std::string key = it->first;
+        v8::Local<v8::String> key_str = Nan::New<v8::String>(key).ToLocalChecked();;
+        keys->Set(k++, key_str);
+    }
+
+    return keys;
+}
+
 void BuboCache::stats(v8::Local<v8::Object>& stats) const {
 
     static PersistentString strings_table("strings_table");

--- a/src/bubo-cache.cc
+++ b/src/bubo-cache.cc
@@ -36,7 +36,7 @@ bool BuboCache::add(const v8::Local<v8::String>& bucket,
     AttributesTable* at = NULL;
     bubo_cache_t::iterator it = bubo_cache_.find(key);
     if (it == bubo_cache_.end()) {
-        at = new AttributesTable(strings_table_, Nan::New(ignored_attributes_));
+        at = new AttributesTable(strings_table_, &ignored_attributes_);
         bubo_cache_.insert(std::make_pair(key, at));
     } else {
         at = it->second;

--- a/src/bubo-cache.cc
+++ b/src/bubo-cache.cc
@@ -75,7 +75,7 @@ void BuboCache::delete_bucket(const v8::Local<v8::String>& bucket) {
 }
 
 v8::Local<v8::Array> BuboCache::get_buckets() {
-    v8::Local<v8::Array> keys = v8::Array::New();
+    v8::Local<v8::Array> keys = Nan::New<v8::Array>();
     int k = 0;
 
     for(bubo_cache_t::iterator it = bubo_cache_.begin(); it != bubo_cache_.end(); ++it) {

--- a/src/bubo-cache.cc
+++ b/src/bubo-cache.cc
@@ -24,7 +24,7 @@ BuboCache::~BuboCache() {
 }
 
 
-bool BuboCache::lookup(const v8::Local<v8::String>& bucket,
+bool BuboCache::add(const v8::Local<v8::String>& bucket,
                        const v8::Local<v8::Object>& pt,
                        v8::Local<v8::String>& attr_str,
                        int* error) {
@@ -37,7 +37,20 @@ bool BuboCache::lookup(const v8::Local<v8::String>& bucket,
     } else {
         at = it->second;
     }
-    return at->lookup(pt, attr_str, error);
+    return at->add(pt, attr_str, error);
+}
+
+bool BuboCache::contains(const v8::Local<v8::String>& bucket,
+                       const v8::Local<v8::Object>& pt,
+                       int* error) {
+    std::string key = stdString(bucket);
+    bubo_cache_t::iterator it = bubo_cache_.find(key);
+    if (it == bubo_cache_.end()) {
+        return false;
+    } else {
+        AttributesTable* at = it->second;
+        return at->contains(pt, error);
+    }
 }
 
 

--- a/src/bubo-cache.cc
+++ b/src/bubo-cache.cc
@@ -64,47 +64,10 @@ void BuboCache::remove(const v8::Local<v8::String>& bucket,
     }
 }
 
-long extractDay(const char* bucket);
-char* extractSpace(const char* bucket);
-
-long extractDay(const char* bucket) {
-    const char* p = bucket;
-    while(*(p++) != '@');
-    return strtol(p, NULL, 10);
-}
-
-int spaceLength(const char* bucket) {
-    int i = 0;
-    while (bucket[i] != '@') {
-        i++;
-    }
-    return i;
-}
-
-void BuboCache::remove_bucket(const v8::Local<v8::String>& bucket) {
-    // Note that the bucket is always a numeric value.
-    // We remove all buckets with numeric value less than or equal to the requested bucket.
+void BuboCache::delete_bucket(const v8::Local<v8::String>& bucket) {
     const v8::String::Utf8Value s(bucket);
-    const char* deleteSpace = *s;
-    int length = spaceLength(deleteSpace);
-    long deleteBucket = extractDay(deleteSpace);
-
-    for (bubo_cache_t::iterator it = bubo_cache_.begin(); it != bubo_cache_.end(); ) {
-        const char* storedString = it->first.c_str();
-
-        if (!strncmp(deleteSpace, storedString, length)) {
-            long storedBucket = extractDay(storedString);
-
-            if (storedBucket <= deleteBucket) {
-                delete it->second;
-                it = bubo_cache_.erase(it);
-            } else {
-                it++;
-            }
-        } else {
-            it++;
-        }
-    }
+    std::string str(*s);
+    bubo_cache_.erase(str);
 }
 
 void BuboCache::stats(v8::Local<v8::Object>& stats) const {

--- a/src/bubo-cache.cc
+++ b/src/bubo-cache.cc
@@ -29,6 +29,7 @@ void BuboCache::initialize(v8::Local<v8::Object> ignoredAttrs) {
 
 bool BuboCache::add(const v8::Local<v8::String>& bucket,
                        const v8::Local<v8::Object>& pt,
+                       bool should_get_attr_str,
                        v8::Local<v8::String>& attr_str,
                        int* error) {
     std::string key = stdString(bucket);
@@ -40,7 +41,7 @@ bool BuboCache::add(const v8::Local<v8::String>& bucket,
     } else {
         at = it->second;
     }
-    return at->add(pt, attr_str, error);
+    return at->add(pt, should_get_attr_str, attr_str, error);
 }
 
 bool BuboCache::contains(const v8::Local<v8::String>& bucket,

--- a/src/bubo-cache.h
+++ b/src/bubo-cache.h
@@ -28,6 +28,8 @@ public:
 
     void delete_bucket(const v8::Local<v8::String>& bucket);
 
+    v8::Local<v8::Array> get_buckets();
+
     void stats(v8::Local<v8::Object>& stats) const;
 
 protected:

--- a/src/bubo-cache.h
+++ b/src/bubo-cache.h
@@ -27,21 +27,7 @@ public:
     void stats(v8::Local<v8::Object>& stats) const;
 
 protected:
-    struct Bucket {
-        std::string spaceBucket_;
-        Bucket(const v8::Local<v8::String>& spaceBucket);
-    };
-    struct BucketHash {
-        size_t operator()(const Bucket& bp) const {
-            return std::hash<std::string>()(bp.spaceBucket_);
-        }
-    };
-    struct BucketComparer {
-        bool operator()(const Bucket& l, const Bucket& r) const {
-            return l.spaceBucket_ == r.spaceBucket_;
-        }
-    };
-    typedef std::unordered_map<Bucket, AttributesTable*, BucketHash, BucketComparer> bubo_cache_t;
+    typedef std::unordered_map<std::string, AttributesTable*> bubo_cache_t;
     bubo_cache_t bubo_cache_;
     StringsTable* strings_table_;
 };

--- a/src/bubo-cache.h
+++ b/src/bubo-cache.h
@@ -26,7 +26,7 @@ public:
     void remove(const v8::Local<v8::String>& bucket,
                 const v8::Local<v8::Object>& pt);
 
-    void remove_bucket(const v8::Local<v8::String>& bucket);
+    void delete_bucket(const v8::Local<v8::String>& bucket);
 
     void stats(v8::Local<v8::Object>& stats) const;
 

--- a/src/bubo-cache.h
+++ b/src/bubo-cache.h
@@ -14,6 +14,8 @@ public:
     BuboCache();
     virtual ~BuboCache();
 
+    void initialize(v8::Local<v8::Object> ignoredAttrs);
+
     bool add(const v8::Local<v8::String>& bucket,
                 const v8::Local<v8::Object>& pt,
                 v8::Local<v8::String>& attr_str,
@@ -36,4 +38,5 @@ protected:
     typedef std::unordered_map<std::string, AttributesTable*> bubo_cache_t;
     bubo_cache_t bubo_cache_;
     StringsTable* strings_table_;
+    Nan::Persistent<v8::Object> ignored_attributes_;
 };

--- a/src/bubo-cache.h
+++ b/src/bubo-cache.h
@@ -14,15 +14,15 @@ public:
     BuboCache();
     virtual ~BuboCache();
 
-    bool lookup(const v8::Local<v8::String>& spaceBucket,
+    bool lookup(const v8::Local<v8::String>& bucket,
                 const v8::Local<v8::Object>& pt,
                 v8::Local<v8::String>& attr_str,
                 int* error);
 
-    void remove(const v8::Local<v8::String>& spaceBucket,
+    void remove(const v8::Local<v8::String>& bucket,
                 const v8::Local<v8::Object>& pt);
 
-    void remove_bucket(const v8::Local<v8::String>& spaceBucket);
+    void remove_bucket(const v8::Local<v8::String>& bucket);
 
     void stats(v8::Local<v8::Object>& stats) const;
 

--- a/src/bubo-cache.h
+++ b/src/bubo-cache.h
@@ -18,6 +18,7 @@ public:
 
     bool add(const v8::Local<v8::String>& bucket,
                 const v8::Local<v8::Object>& pt,
+                bool should_get_attr_str,
                 v8::Local<v8::String>& attr_str,
                 int* error);
 

--- a/src/bubo-cache.h
+++ b/src/bubo-cache.h
@@ -14,9 +14,13 @@ public:
     BuboCache();
     virtual ~BuboCache();
 
-    bool lookup(const v8::Local<v8::String>& bucket,
+    bool add(const v8::Local<v8::String>& bucket,
                 const v8::Local<v8::Object>& pt,
                 v8::Local<v8::String>& attr_str,
+                int* error);
+
+    bool contains(const v8::Local<v8::String>& bucket,
+                const v8::Local<v8::Object>& pt,
                 int* error);
 
     void remove(const v8::Local<v8::String>& bucket,

--- a/src/bubo-ht.h
+++ b/src/bubo-ht.h
@@ -102,6 +102,13 @@ public:
         return !found;
     }
 
+    inline bool contains(const BYTE* entry_buf, int entry_len) {
+        assert(entry_buf);
+        uint32_t idx = hash(entry_buf, entry_len) % table_size_;
+
+        return find_at(&table_[idx], entry_buf, entry_len);
+    }
+
     inline void erase(BYTE* val) {
         int len = bubo_utils::get_entry_len(val);
         uint32_t idx = hash(val, len) % table_size_;

--- a/src/bubo.cc
+++ b/src/bubo.cc
@@ -22,7 +22,6 @@ NAN_METHOD(NewInstance) {
 
 NAN_METHOD(Bubo::New)
 {
-
     if (!info.IsConstructCall()) {
         return Nan::ThrowError("non-constructor invocation not supported");
     }

--- a/src/bubo.cc
+++ b/src/bubo.cc
@@ -111,12 +111,12 @@ JS_METHOD(Bubo, Contains)
 }
 
 
-JS_METHOD(Bubo, RemovePoint)
+JS_METHOD(Bubo, Delete)
 {
     Nan::HandleScope scope;
 
     if (info.Length() < 2) {
-        return Nan::ThrowError("RemovePoint: invalid arguments");
+        return Nan::ThrowError("Delete: invalid arguments");
     }
 
     Local<String> bucket = info[0].As<String>();
@@ -178,7 +178,7 @@ Bubo::Init(Handle<Object> exports)
     // Prototype
     Nan::SetPrototypeMethod(tpl, "add", JS_METHOD_NAME(Add));
     Nan::SetPrototypeMethod(tpl, "contains", JS_METHOD_NAME(Contains));
-    Nan::SetPrototypeMethod(tpl, "remove_point", JS_METHOD_NAME(RemovePoint));
+    Nan::SetPrototypeMethod(tpl, "delete", JS_METHOD_NAME(Delete));
     Nan::SetPrototypeMethod(tpl, "remove_bucket", JS_METHOD_NAME(RemoveBucket));
     Nan::SetPrototypeMethod(tpl, "test", JS_METHOD_NAME(Test));
     Nan::SetPrototypeMethod(tpl, "stats", JS_METHOD_NAME(Stats));

--- a/src/bubo.cc
+++ b/src/bubo.cc
@@ -64,19 +64,20 @@ NAN_METHOD(Bubo::Initialize)
 JS_METHOD(Bubo, Add)
 {
     Nan::HandleScope scope;
+    int num_arguments = info.Length();
 
-    if (info.Length() < 3) {
+    if (num_arguments < 2) {
         return Nan::ThrowError("Add: invalid arguments");
     }
 
     Local<String> bucket = info[0].As<String>();
     Local<Object> obj = info[1].As<Object>();
-    Local<Object> result = info[2].As<Object>();
 
     Local<String> attrs;
     int error_value = 0;
     int* error = &error_value;
-    bool found = cache_.add(bucket, obj, attrs, error);
+    bool should_get_attr_str = num_arguments >= 3;
+    bool found = cache_.add(bucket, obj, should_get_attr_str, attrs, error);
 
     if (*error) {
         return Nan::ThrowError("point too big");
@@ -84,7 +85,10 @@ JS_METHOD(Bubo, Add)
 
     static PersistentString attr_str("attr_str");
 
-    Nan::Set(result, attr_str, attrs);
+    if (should_get_attr_str) {
+        Local<Object> result = info[2].As<Object>();
+        Nan::Set(result, attr_str, attrs);
+    }
 
     info.GetReturnValue().Set(found);
 }

--- a/src/bubo.cc
+++ b/src/bubo.cc
@@ -61,12 +61,12 @@ NAN_METHOD(Bubo::Initialize)
     bubo_utils::initialize(ignored);
 }
 
-JS_METHOD(Bubo, LookupPoint)
+JS_METHOD(Bubo, Add)
 {
     Nan::HandleScope scope;
 
     if (info.Length() < 3) {
-        return Nan::ThrowError("LookupPoint: invalid arguments");
+        return Nan::ThrowError("Add: invalid arguments");
     }
 
     Local<String> bucket = info[0].As<String>();
@@ -82,13 +82,11 @@ JS_METHOD(Bubo, LookupPoint)
         return Nan::ThrowError("point too big");
     }
 
-    static PersistentString founded("found");
     static PersistentString attr_str("attr_str");
 
-    Nan::Set(result, founded, Nan::New<Boolean>(found));
     Nan::Set(result, attr_str, attrs);
 
-    return;
+    info.GetReturnValue().Set(found);
 }
 
 
@@ -157,7 +155,7 @@ Bubo::Init(Handle<Object> exports)
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
     // Prototype
-    Nan::SetPrototypeMethod(tpl, "lookup_point", JS_METHOD_NAME(LookupPoint));
+    Nan::SetPrototypeMethod(tpl, "add", JS_METHOD_NAME(Add));
     Nan::SetPrototypeMethod(tpl, "remove_point", JS_METHOD_NAME(RemovePoint));
     Nan::SetPrototypeMethod(tpl, "remove_bucket", JS_METHOD_NAME(RemoveBucket));
     Nan::SetPrototypeMethod(tpl, "test", JS_METHOD_NAME(Test));

--- a/src/bubo.cc
+++ b/src/bubo.cc
@@ -58,7 +58,7 @@ NAN_METHOD(Bubo::Initialize)
     Local<Value> ignoredVal = Nan::Get(opts, ignoredAttributes).ToLocalChecked();
     Local<Object> ignored = Nan::To<Object>(ignoredVal).ToLocalChecked();
 
-    bubo_utils::initialize(ignored);
+    cache_.initialize(ignored);
 }
 
 JS_METHOD(Bubo, Add)

--- a/src/bubo.cc
+++ b/src/bubo.cc
@@ -142,6 +142,14 @@ JS_METHOD(Bubo, DeleteBucket)
     return;
 }
 
+JS_METHOD(Bubo, GetBuckets) {
+    Nan::HandleScope scope;
+
+    v8::Local<v8::Array> buckets = cache_.get_buckets();
+
+    info.GetReturnValue().Set(buckets);
+}
+
 JS_METHOD(Bubo, Test)
 {
     Nan::HandleScope scope;
@@ -180,6 +188,7 @@ Bubo::Init(Handle<Object> exports)
     Nan::SetPrototypeMethod(tpl, "contains", JS_METHOD_NAME(Contains));
     Nan::SetPrototypeMethod(tpl, "delete", JS_METHOD_NAME(Delete));
     Nan::SetPrototypeMethod(tpl, "delete_bucket", JS_METHOD_NAME(DeleteBucket));
+    Nan::SetPrototypeMethod(tpl, "get_buckets", JS_METHOD_NAME(GetBuckets));
     Nan::SetPrototypeMethod(tpl, "test", JS_METHOD_NAME(Test));
     Nan::SetPrototypeMethod(tpl, "stats", JS_METHOD_NAME(Stats));
 

--- a/src/bubo.cc
+++ b/src/bubo.cc
@@ -128,16 +128,16 @@ JS_METHOD(Bubo, Delete)
 }
 
 
-JS_METHOD(Bubo, RemoveBucket)
+JS_METHOD(Bubo, DeleteBucket)
 {
     Nan::HandleScope scope;
 
     if (info.Length() < 1) {
-        return Nan::ThrowError("RemoveBucket: invalid arguments");
+        return Nan::ThrowError("DeleteBucket: invalid arguments");
     }
 
     Local<String> bucket = info[0].As<String>();
-    cache_.remove_bucket(bucket);
+    cache_.delete_bucket(bucket);
 
     return;
 }
@@ -179,7 +179,7 @@ Bubo::Init(Handle<Object> exports)
     Nan::SetPrototypeMethod(tpl, "add", JS_METHOD_NAME(Add));
     Nan::SetPrototypeMethod(tpl, "contains", JS_METHOD_NAME(Contains));
     Nan::SetPrototypeMethod(tpl, "delete", JS_METHOD_NAME(Delete));
-    Nan::SetPrototypeMethod(tpl, "remove_bucket", JS_METHOD_NAME(RemoveBucket));
+    Nan::SetPrototypeMethod(tpl, "delete_bucket", JS_METHOD_NAME(DeleteBucket));
     Nan::SetPrototypeMethod(tpl, "test", JS_METHOD_NAME(Test));
     Nan::SetPrototypeMethod(tpl, "stats", JS_METHOD_NAME(Stats));
 

--- a/src/bubo.cc
+++ b/src/bubo.cc
@@ -76,7 +76,7 @@ JS_METHOD(Bubo, Add)
     Local<String> attrs;
     int error_value = 0;
     int* error = &error_value;
-    bool found = cache_.lookup(bucket, obj, attrs, error);
+    bool found = cache_.add(bucket, obj, attrs, error);
 
     if (*error) {
         return Nan::ThrowError("point too big");
@@ -85,6 +85,27 @@ JS_METHOD(Bubo, Add)
     static PersistentString attr_str("attr_str");
 
     Nan::Set(result, attr_str, attrs);
+
+    info.GetReturnValue().Set(found);
+}
+
+JS_METHOD(Bubo, Contains)
+{
+    Nan::HandleScope scope;
+
+    if (info.Length() < 2) {
+        return Nan::ThrowError("Contains: invalid arguments");
+    }
+
+    Local<String> bucket = info[0].As<String>();
+    Local<Object> obj = info[1].As<Object>();
+
+    int error_value = 0;
+    int* error = &error_value;
+    bool found = cache_.contains(bucket, obj, error);
+    if (*error) {
+        return Nan::ThrowError("point too big");
+    }
 
     info.GetReturnValue().Set(found);
 }
@@ -156,6 +177,7 @@ Bubo::Init(Handle<Object> exports)
 
     // Prototype
     Nan::SetPrototypeMethod(tpl, "add", JS_METHOD_NAME(Add));
+    Nan::SetPrototypeMethod(tpl, "contains", JS_METHOD_NAME(Contains));
     Nan::SetPrototypeMethod(tpl, "remove_point", JS_METHOD_NAME(RemovePoint));
     Nan::SetPrototypeMethod(tpl, "remove_bucket", JS_METHOD_NAME(RemoveBucket));
     Nan::SetPrototypeMethod(tpl, "test", JS_METHOD_NAME(Test));

--- a/src/bubo.cc
+++ b/src/bubo.cc
@@ -69,14 +69,14 @@ JS_METHOD(Bubo, LookupPoint)
         return Nan::ThrowError("LookupPoint: invalid arguments");
     }
 
-    Local<String> spaceBucket = info[0].As<String>();
+    Local<String> bucket = info[0].As<String>();
     Local<Object> obj = info[1].As<Object>();
     Local<Object> result = info[2].As<Object>();
 
     Local<String> attrs;
     int error_value = 0;
     int* error = &error_value;
-    bool found = cache_.lookup(spaceBucket, obj, attrs, error);
+    bool found = cache_.lookup(bucket, obj, attrs, error);
 
     if (*error) {
         return Nan::ThrowError("point too big");
@@ -100,10 +100,10 @@ JS_METHOD(Bubo, RemovePoint)
         return Nan::ThrowError("RemovePoint: invalid arguments");
     }
 
-    Local<String> spaceBucket = info[0].As<String>();
+    Local<String> bucket = info[0].As<String>();
     Local<Object> obj = info[1].As<Object>();
 
-    cache_.remove(spaceBucket, obj);
+    cache_.remove(bucket, obj);
 
     return;
 }
@@ -117,8 +117,8 @@ JS_METHOD(Bubo, RemoveBucket)
         return Nan::ThrowError("RemoveBucket: invalid arguments");
     }
 
-    Local<String> spaceBucket = info[0].As<String>();
-    cache_.remove_bucket(spaceBucket);
+    Local<String> bucket = info[0].As<String>();
+    cache_.remove_bucket(bucket);
 
     return;
 }

--- a/src/bubo.h
+++ b/src/bubo.h
@@ -23,7 +23,7 @@ private:
     JS_METHOD_DECL(Add);
     JS_METHOD_DECL(Contains);
     JS_METHOD_DECL(Delete);
-    JS_METHOD_DECL(RemoveBucket);
+    JS_METHOD_DECL(DeleteBucket);
     JS_METHOD_DECL(Stats);
     JS_METHOD_DECL(Test);
 

--- a/src/bubo.h
+++ b/src/bubo.h
@@ -24,6 +24,7 @@ private:
     JS_METHOD_DECL(Contains);
     JS_METHOD_DECL(Delete);
     JS_METHOD_DECL(DeleteBucket);
+    JS_METHOD_DECL(GetBuckets);
     JS_METHOD_DECL(Stats);
     JS_METHOD_DECL(Test);
 

--- a/src/bubo.h
+++ b/src/bubo.h
@@ -20,7 +20,7 @@ private:
 
     NAN_METHOD(Initialize);
 
-    JS_METHOD_DECL(LookupPoint);
+    JS_METHOD_DECL(Add);
     JS_METHOD_DECL(RemovePoint);
     JS_METHOD_DECL(RemoveBucket);
     JS_METHOD_DECL(Stats);

--- a/src/bubo.h
+++ b/src/bubo.h
@@ -21,6 +21,7 @@ private:
     NAN_METHOD(Initialize);
 
     JS_METHOD_DECL(Add);
+    JS_METHOD_DECL(Contains);
     JS_METHOD_DECL(RemovePoint);
     JS_METHOD_DECL(RemoveBucket);
     JS_METHOD_DECL(Stats);

--- a/src/bubo.h
+++ b/src/bubo.h
@@ -22,7 +22,7 @@ private:
 
     JS_METHOD_DECL(Add);
     JS_METHOD_DECL(Contains);
-    JS_METHOD_DECL(RemovePoint);
+    JS_METHOD_DECL(Delete);
     JS_METHOD_DECL(RemoveBucket);
     JS_METHOD_DECL(Stats);
     JS_METHOD_DECL(Test);

--- a/src/test.cc
+++ b/src/test.cc
@@ -9,7 +9,7 @@
 #include "attrs-table.h"
 #include "bubo-ht.h"
 
-static v8::Handle<v8::Object> ignored_attributes;
+static Nan::Persistent<v8::Object> ignored_attributes;
 
 static void test_hash_function_same_input() {
     BYTE a[5];
@@ -290,7 +290,7 @@ static void test_strings_table_sizes() {
 static void test_strings_table_entry_buf_basic() {
     // tests if basic functionality of prepare_entry_buffer() is allright.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
 
     v8::Local<v8::Object> pt = Nan::New<v8::Object>();
     Nan::Set(pt, Nan::New("proxy").ToLocalChecked(), Nan::New("sfdc1").ToLocalChecked());              // tag seq 1 -> position 3 sorted.
@@ -326,7 +326,7 @@ static void test_strings_table_entry_buf_basic() {
 static void test_strings_table_entry_buf_repeated() {
     // tests if functionality of prepare_entry_buffer() is allright when things repeat.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
 
     int buflen = 0;
 
@@ -372,7 +372,7 @@ static void test_strings_table_entry_buf_repeated() {
 static void test_strings_table_entry_buf_large_seq() {
     // Test for sequence numbers larger than 127 (these will require more than 1 byte)
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
 
     v8::Local<v8::String> tbase = Nan::New("mytag").ToLocalChecked();
     v8::Local<v8::String> vbase = Nan::New("myval").ToLocalChecked();
@@ -422,7 +422,7 @@ static void test_strings_table_entry_buf_large_seq() {
 void test_strings_table_wide_point() {
     // tests if prepare_entry_buffer() works with relatively wide inputs.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
 
     BYTE* buf = NULL;
     int buflen = 0;
@@ -585,5 +585,4 @@ void testall() {
 
     test_hash_set();
     test_hash_set_add_many_erase();
-
 }

--- a/src/test.cc
+++ b/src/test.cc
@@ -9,6 +9,7 @@
 #include "attrs-table.h"
 #include "bubo-ht.h"
 
+static v8::Handle<v8::Object> ignored_attributes;
 
 static void test_hash_function_same_input() {
     BYTE a[5];
@@ -289,7 +290,7 @@ static void test_strings_table_sizes() {
 static void test_strings_table_entry_buf_basic() {
     // tests if basic functionality of prepare_entry_buffer() is allright.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st);
+    AttributesTable* at = new AttributesTable(st, ignored_attributes);
 
     v8::Local<v8::Object> pt = Nan::New<v8::Object>();
     Nan::Set(pt, Nan::New("proxy").ToLocalChecked(), Nan::New("sfdc1").ToLocalChecked());              // tag seq 1 -> position 3 sorted.
@@ -325,7 +326,7 @@ static void test_strings_table_entry_buf_basic() {
 static void test_strings_table_entry_buf_repeated() {
     // tests if functionality of prepare_entry_buffer() is allright when things repeat.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st);
+    AttributesTable* at = new AttributesTable(st, ignored_attributes);
 
     int buflen = 0;
 
@@ -371,7 +372,7 @@ static void test_strings_table_entry_buf_repeated() {
 static void test_strings_table_entry_buf_large_seq() {
     // Test for sequence numbers larger than 127 (these will require more than 1 byte)
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st);
+    AttributesTable* at = new AttributesTable(st, ignored_attributes);
 
     v8::Local<v8::String> tbase = Nan::New("mytag").ToLocalChecked();
     v8::Local<v8::String> vbase = Nan::New("myval").ToLocalChecked();
@@ -421,7 +422,7 @@ static void test_strings_table_entry_buf_large_seq() {
 void test_strings_table_wide_point() {
     // tests if prepare_entry_buffer() works with relatively wide inputs.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st);
+    AttributesTable* at = new AttributesTable(st, ignored_attributes);
 
     BYTE* buf = NULL;
     int buflen = 0;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -6,12 +6,6 @@ using namespace v8;
 
 namespace bubo_utils {
 
-Nan::Persistent<v8::Object> ignoredAttrs_;
-
-void initialize(Local<Object> ignoredAttrs) {
-    ignoredAttrs_.Reset(ignoredAttrs);
-}
-
 void hex_out(const BYTE* data, int len, const char* hint) {
     printf("%s [%p][%d]\n", (hint ? hint : ""), data, len);
 
@@ -22,11 +16,4 @@ void hex_out(const BYTE* data, int len, const char* hint) {
     printf("\n\n");
 }
 
-bool is_ignored_attribute(const Local<String>& attr)
-{
-    if (ignoredAttrs_.IsEmpty()) {
-        return false;
-    }
-    return Nan::HasOwnProperty(Nan::New(ignoredAttrs_), attr).FromJust();
-}
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -23,8 +23,6 @@ void initialize(v8::Local<v8::Object> ignoredAttrs);
 
 void hex_out(const BYTE* data, int len, const char* hint=NULL);
 
-bool is_ignored_attribute(const v8::Local<v8::String>& attr);
-
 // Using Google's protobuffer encoding (https://github.com/google/protobuf)
 inline void encode_packed(uint32_t val, BYTE* out, int* outlen) {
     int length = 1;

--- a/test/bubo.spec.js
+++ b/test/bubo.spec.js
@@ -274,6 +274,47 @@ describe('bubo', function() {
         expect(s1['spc@bkt'].blob_used_bytes).equal(18); // 1 byte for size + 2 x 2 bytes = 5. already have 13, so total 18.
     });
 
+    it('has an ignoredAttributes per Bubo', function() {
+        var bucket = 'ignored_attributes_bucket';
+        var pt = {
+            name: 'cpu.system',
+            pop: 'SF',
+            host: 'foo.com',
+            time: new Date(),
+            time2: new Date(),
+            value: 100,
+            value2: 100,
+            value3: 100.999,
+            source_type: 'metric',
+        };
+
+        var ignoredAttributes1 = {
+            time: true
+        };
+
+        var ignoredAttributes2 = {
+            time: true,
+            pop: true,
+            name: true
+        };
+
+        var bubo1 = new Bubo({
+            ignoredAttributes: ignoredAttributes1
+        });
+
+        var bubo2 = new Bubo({
+            ignoredAttributes: ignoredAttributes2
+        });
+
+        var expected1 = getAttributeString(pt, ignoredAttributes1);
+        add(bubo1, bucket, pt);
+        expect(result.attr_str).equal(expected1);
+
+        var expected2 = getAttributeString(pt, ignoredAttributes2);
+        add(bubo2, bucket, pt);
+        expect(result.attr_str).equal(expected2);
+    });
+
     it.skip('profiles the memory use of adding 7 million points', function() {
         this.timeout(900000);
         var bubo = new Bubo(options);

--- a/test/bubo.spec.js
+++ b/test/bubo.spec.js
@@ -165,7 +165,7 @@ describe('bubo', function() {
         expect(contains(bubo, bucket, pt)).equal(false);
     });
 
-    it('handles remove_bucket correctly', function() {
+    it('handles delete_bucket correctly', function() {
         var bubo = new Bubo(options);
 
         var pt = {
@@ -180,75 +180,14 @@ describe('bubo', function() {
             source_type: 'metric',
         };
 
-        var v;
+        var bucket = 'delete_this_bucket';
 
-        /*
-        Create the point in these space-bucket combinations by performing a add:
-            s1,12
-            s1,22
-            s1,32
-            s1,42
-            s1.52
-            s2,42
-            s3,52
-        First time all are not found.
+        var found = add(bubo, bucket, pt);
+        expect(found).to.be.false;
+        expect(contains(bubo, bucket, pt)).equal(true);
 
-        Now, remove_bucket(s1, 12), and add all again.
-        All but (s1,12) should be true.
-
-        Now, remove_space(s1,32), and add again.
-        Since all buckets <= 32 should have been removed, and hence should be false.
-        */
-
-        found = add(bubo, 's1@12', pt);
-        expect(found).to.be.false;
-        found = add(bubo, 's1@22', pt);
-        expect(found).to.be.false;
-        found = add(bubo, 's1@32', pt);
-        expect(found).to.be.false;
-        found = add(bubo, 's1@42', pt);
-        expect(found).to.be.false;
-        found = add(bubo, 's1@52', pt);
-        expect(found).to.be.false;
-        found = add(bubo, 's2@42', pt);
-        expect(found).to.be.false;
-        found = add(bubo, 's3@52', pt);
-        expect(found).to.be.false;
-
-        bubo.remove_bucket('s1@12');
-
-        found = add(bubo, 's1@12', pt);
-        expect(found).to.be.false;
-        found = add(bubo, 's1@22', pt);
-        expect(found).to.be.true;
-        found = add(bubo, 's1@32', pt);
-        expect(found).to.be.true;
-        found = add(bubo, 's1@42', pt);
-        expect(found).to.be.true;
-        found = add(bubo, 's1@52', pt);
-        expect(found).to.be.true;
-        found = add(bubo, 's2@42', pt);
-        expect(found).to.be.true;
-        found = add(bubo, 's3@52', pt);
-        expect(found).to.be.true;
-
-        // Use integer second param to ensure both integer and string are accepted.
-        bubo.remove_bucket('s1@32');
-
-        found = add(bubo, 's1@12', pt);
-        expect(found).to.be.false;
-        found = add(bubo, 's1@22', pt);
-        expect(found).to.be.false;
-        found = add(bubo, 's1@32', pt);
-        expect(found).to.be.false;
-        found = add(bubo, 's1@42', pt);
-        expect(found).to.be.true;
-        found = add(bubo, 's1@52', pt);
-        expect(found).to.be.true;
-        found = add(bubo, 's2@42', pt);
-        expect(found).to.be.true;
-        found = add(bubo, 's3@52', pt);
-        expect(found).to.be.true;
+        bubo.delete_bucket(bucket);
+        expect(contains(bubo, bucket, pt)).equal(false);
     });
 
     it('returns appropriate stats', function() {

--- a/test/bubo.spec.js
+++ b/test/bubo.spec.js
@@ -26,9 +26,8 @@ function getAttributeString(pt, ignoredAttributes) {
 
 var result = {};
 
-function lookup(bubo, bucket, point) {
-    bubo.lookup_point(bucket, point, result);
-    return result;
+function add(bubo, bucket, point) {
+    return bubo.add(bucket, point, result);
 }
 
 var options = {}
@@ -37,11 +36,11 @@ describe('bubo', function() {
     it('initializes properly', function() {
         var bubo = new Bubo(options);
 
-        expect(bubo.lookup_point).is.a.function;
+        expect(bubo.add).is.a.function;
 
         expect(function() {
-            bubo.lookup_point({});
-        }).to.throw('LookupPoint: invalid arguments');
+            bubo.add({});
+        }).to.throw('Add: invalid arguments');
 
     });
 
@@ -50,7 +49,7 @@ describe('bubo', function() {
         bubo.test();
     });
 
-    it('handles lookup and remove correctly', function() {
+    it('handles add and remove correctly', function() {
         var bubo = new Bubo(options);
 
         var pt = {
@@ -67,40 +66,40 @@ describe('bubo', function() {
 
         var expected = getAttributeString(pt);
 
-        // Lookup in different space-buckets combinations.
+        // add in different space-buckets combinations.
         // The 'found' should be false when the space-bucket is called first time.
 
-        var v = lookup(bubo, 'aaa', pt);
-        expect(v.attr_str).equal(expected);
-        expect(v.found).to.be.false;
+        var found = add(bubo, 'aaa', pt);
+        expect(result.attr_str).equal(expected);
+        expect(found).to.be.false;
 
-        v = lookup(bubo, 'bbb', pt);
-        expect(v.attr_str).equal(expected);
-        expect(v.found).to.be.false;
+        found = add(bubo, 'bbb', pt);
+        expect(result.attr_str).equal(expected);
+        expect(found).to.be.false;
 
-        v = lookup(bubo, 'ccc', pt);
-        expect(v.attr_str).equal(expected);
-        expect(v.found).to.be.false;
+        found = add(bubo, 'ccc', pt);
+        expect(result.attr_str).equal(expected);
+        expect(found).to.be.false;
 
         // The same calls should have found == true the second time.
-        v = lookup(bubo, 'aaa', pt);
-        expect(v.attr_str).equal(expected);
-        expect(v.found).to.be.true;
+        found = add(bubo, 'aaa', pt);
+        expect(result.attr_str).equal(expected);
+        expect(found).to.be.true;
 
-        v = lookup(bubo, 'bbb', pt);
-        expect(v.attr_str).equal(expected);
-        expect(v.found).to.be.true;
+        found = add(bubo, 'bbb', pt);
+        expect(result.attr_str).equal(expected);
+        expect(found).to.be.true;
 
-        v = lookup(bubo, 'ccc', pt);
-        expect(v.attr_str).equal(expected);
-        expect(v.found).to.be.true;
+        found = add(bubo, 'ccc', pt);
+        expect(result.attr_str).equal(expected);
+        expect(found).to.be.true;
 
-        // modify pt and lookup. This should be false, and the attr_atr should differ from expected.
+        // modify pt and add. This should be false, and the attr_atr should differ from expected.
         var pt2 = JSON.parse(JSON.stringify(pt));
         pt2.pop = 'NY';
-        v = lookup(bubo, 'aaa', pt2);
-        expect(v.attr_str).not.equal(expected);
-        expect(v.found).to.be.false;
+        found = add(bubo, 'aaa', pt2);
+        expect(result.attr_str).not.equal(expected);
+        expect(found).to.be.false;
 
     });
 
@@ -122,7 +121,7 @@ describe('bubo', function() {
         var v;
 
         /*
-        Create the point in these space-bucket combinations by performing a lookup:
+        Create the point in these space-bucket combinations by performing a add:
             s1,12
             s1,22
             s1,32
@@ -132,62 +131,62 @@ describe('bubo', function() {
             s3,52
         First time all are not found.
 
-        Now, remove_bucket(s1, 12), and lookup all again.
+        Now, remove_bucket(s1, 12), and add all again.
         All but (s1,12) should be true.
 
-        Now, remove_space(s1,32), and lookup again.
+        Now, remove_space(s1,32), and add again.
         Since all buckets <= 32 should have been removed, and hence should be false.
         */
 
-        v = lookup(bubo, 's1@12', pt);
-        expect(v.found).to.be.false;
-        v = lookup(bubo, 's1@22', pt);
-        expect(v.found).to.be.false;
-        v = lookup(bubo, 's1@32', pt);
-        expect(v.found).to.be.false;
-        v = lookup(bubo, 's1@42', pt);
-        expect(v.found).to.be.false;
-        v = lookup(bubo, 's1@52', pt);
-        expect(v.found).to.be.false;
-        v = lookup(bubo, 's2@42', pt);
-        expect(v.found).to.be.false;
-        v = lookup(bubo, 's3@52', pt);
-        expect(v.found).to.be.false;
+        found = add(bubo, 's1@12', pt);
+        expect(found).to.be.false;
+        found = add(bubo, 's1@22', pt);
+        expect(found).to.be.false;
+        found = add(bubo, 's1@32', pt);
+        expect(found).to.be.false;
+        found = add(bubo, 's1@42', pt);
+        expect(found).to.be.false;
+        found = add(bubo, 's1@52', pt);
+        expect(found).to.be.false;
+        found = add(bubo, 's2@42', pt);
+        expect(found).to.be.false;
+        found = add(bubo, 's3@52', pt);
+        expect(found).to.be.false;
 
         bubo.remove_bucket('s1@12');
 
-        v = lookup(bubo, 's1@12', pt);
-        expect(v.found).to.be.false;
-        v = lookup(bubo, 's1@22', pt);
-        expect(v.found).to.be.true;
-        v = lookup(bubo, 's1@32', pt);
-        expect(v.found).to.be.true;
-        v = lookup(bubo, 's1@42', pt);
-        expect(v.found).to.be.true;
-        v = lookup(bubo, 's1@52', pt);
-        expect(v.found).to.be.true;
-        v = lookup(bubo, 's2@42', pt);
-        expect(v.found).to.be.true;
-        v = lookup(bubo, 's3@52', pt);
-        expect(v.found).to.be.true;
+        found = add(bubo, 's1@12', pt);
+        expect(found).to.be.false;
+        found = add(bubo, 's1@22', pt);
+        expect(found).to.be.true;
+        found = add(bubo, 's1@32', pt);
+        expect(found).to.be.true;
+        found = add(bubo, 's1@42', pt);
+        expect(found).to.be.true;
+        found = add(bubo, 's1@52', pt);
+        expect(found).to.be.true;
+        found = add(bubo, 's2@42', pt);
+        expect(found).to.be.true;
+        found = add(bubo, 's3@52', pt);
+        expect(found).to.be.true;
 
         // Use integer second param to ensure both integer and string are accepted.
         bubo.remove_bucket('s1@32');
 
-        v = lookup(bubo, 's1@12', pt);
-        expect(v.found).to.be.false;
-        v = lookup(bubo, 's1@22', pt);
-        expect(v.found).to.be.false;
-        v = lookup(bubo, 's1@32', pt);
-        expect(v.found).to.be.false;
-        v = lookup(bubo, 's1@42', pt);
-        expect(v.found).to.be.true;
-        v = lookup(bubo, 's1@52', pt);
-        expect(v.found).to.be.true;
-        v = lookup(bubo, 's2@42', pt);
-        expect(v.found).to.be.true;
-        v = lookup(bubo, 's3@52', pt);
-        expect(v.found).to.be.true;
+        found = add(bubo, 's1@12', pt);
+        expect(found).to.be.false;
+        found = add(bubo, 's1@22', pt);
+        expect(found).to.be.false;
+        found = add(bubo, 's1@32', pt);
+        expect(found).to.be.false;
+        found = add(bubo, 's1@42', pt);
+        expect(found).to.be.true;
+        found = add(bubo, 's1@52', pt);
+        expect(found).to.be.true;
+        found = add(bubo, 's2@42', pt);
+        expect(found).to.be.true;
+        found = add(bubo, 's3@52', pt);
+        expect(found).to.be.true;
     });
 
     it('returns appropriate stats', function() {
@@ -216,7 +215,7 @@ describe('bubo', function() {
             source_type: 'metric'
         };
 
-        var v = lookup(bubo, 'spc@bkt', pt);
+        var found = add(bubo, 'spc@bkt', pt);
         s1 = {};
         bubo.stats(s1);
 
@@ -231,7 +230,7 @@ describe('bubo', function() {
             name: 'apple',
             pop: 'NY',
         };
-        v = lookup(bubo, 'spc@bkt', pt);
+        found = add(bubo, 'spc@bkt', pt);
         s1 = {};
         bubo.stats(s1);
 
@@ -265,7 +264,7 @@ describe('bubo', function() {
         for (var i = 0; i < 7000000; i++) {
             pt.pop = 'SF' + i;
             pt.value2 = pt.value2 + (2* i);
-            lookup(bubo, 'test-space-1@421', pt);
+            add(bubo, 'test-space-1@421', pt);
             if (i % 1000000 === 0) {
                 s1 = {};
                 bubo.stats(s1);
@@ -297,8 +296,8 @@ describe('bubo', function() {
         };
 
         try {
-            lookup(bubo, 'big@data', point);
-            throw new Error('lookup should have failed');
+            add(bubo, 'big@data', point);
+            throw new Error('add should have failed');
         } catch (err) {
             expect(err.message).equal('point too big');
         }

--- a/test/bubo.spec.js
+++ b/test/bubo.spec.js
@@ -3,10 +3,10 @@ var _ = require('underscore');
 var expect = require('chai').expect;
 var util = require('util');
 
-function getAttributeString(pt, ignoredAttributes) {
+function getAttributeString(point, ignoredAttributes) {
     ignoredAttributes = ignoredAttributes || {};
     var keys = [];
-    _.each(pt, function(val, key) {
+    _.each(point, function(val, key) {
         if (!ignoredAttributes[key]) {
             keys.push(key);
         }
@@ -17,7 +17,7 @@ function getAttributeString(pt, ignoredAttributes) {
     var attrString = '';
     var comma = '';
     for (var tag = keys.length - 1; tag >= 0; tag--) {
-        attrString = keys[tag] + '=' + pt[keys[tag]] + comma + attrString;
+        attrString = keys[tag] + '=' + point[keys[tag]] + comma + attrString;
         comma = ',';
     }
 
@@ -37,6 +37,18 @@ function contains(bubo, bucket, point) {
 var options = {}
 
 describe('bubo', function() {
+    var point = {
+        name: 'cpu.system',
+        pop: 'SF',
+        host: 'foo.com',
+        time: new Date(),
+        time2: new Date(),
+        value: 100,
+        value2: 100,
+        value3: 100.999,
+        source_type: 'metric',
+    };
+
     it('initializes properly', function() {
         var bubo = new Bubo(options);
 
@@ -56,52 +68,40 @@ describe('bubo', function() {
     it('handles add and remove correctly', function() {
         var bubo = new Bubo(options);
 
-        var pt = {
-            name: 'cpu.system',
-            pop: 'SF',
-            host: 'foo.com',
-            time: new Date(),
-            time2: new Date(),
-            value: 100,
-            value2: 100,
-            value3: 100.999,
-            source_type: 'metric',
-        };
-
-        var expected = getAttributeString(pt);
+        var expected = getAttributeString(point);
 
         // add in different space-buckets combinations.
         // The 'found' should be false when the space-bucket is called first time.
 
-        var found = add(bubo, 'aaa', pt);
+        var found = add(bubo, 'aaa', point);
         expect(result.attr_str).equal(expected);
         expect(found).to.be.false;
 
-        found = add(bubo, 'bbb', pt);
+        found = add(bubo, 'bbb', point);
         expect(result.attr_str).equal(expected);
         expect(found).to.be.false;
 
-        found = add(bubo, 'ccc', pt);
+        found = add(bubo, 'ccc', point);
         expect(result.attr_str).equal(expected);
         expect(found).to.be.false;
 
         // The same calls should have found == true the second time.
-        found = add(bubo, 'aaa', pt);
+        found = add(bubo, 'aaa', point);
         expect(result.attr_str).equal(expected);
         expect(found).to.be.true;
 
-        found = add(bubo, 'bbb', pt);
+        found = add(bubo, 'bbb', point);
         expect(result.attr_str).equal(expected);
         expect(found).to.be.true;
 
-        found = add(bubo, 'ccc', pt);
+        found = add(bubo, 'ccc', point);
         expect(result.attr_str).equal(expected);
         expect(found).to.be.true;
 
-        // modify pt and add. This should be false, and the attr_atr should differ from expected.
-        var pt2 = JSON.parse(JSON.stringify(pt));
-        pt2.pop = 'NY';
-        found = add(bubo, 'aaa', pt2);
+        // modify point and add. This should be false, and the attr_atr should differ from expected.
+        var point2 = JSON.parse(JSON.stringify(point));
+        point2.pop = 'NY';
+        found = add(bubo, 'aaa', point2);
         expect(result.attr_str).not.equal(expected);
         expect(found).to.be.false;
 
@@ -111,85 +111,48 @@ describe('bubo', function() {
         var bubo = new Bubo(options);
         var bucket = 'contains_bucket';
 
-        var pt = {
-            name: 'cpu.system',
-            pop: 'SF',
-            host: 'foo.com',
-            time: new Date(),
-            time2: new Date(),
-            value: 100,
-            value2: 100,
-            value3: 100.999,
-            source_type: 'metric',
-        };
-
-        var found = contains(bubo, bucket, pt);
+        var found = contains(bubo, bucket, point);
         expect(found).equal(false);
 
-        found = contains(bubo, bucket, pt);
+        found = contains(bubo, bucket, point);
         expect(found).equal(false);
 
-        found = add(bubo, bucket, pt);
+        found = add(bubo, bucket, point);
         expect(found).equal(false);
 
-        found = contains(bubo, bucket, pt);
+        found = contains(bubo, bucket, point);
         expect(found).equal(true);
 
-        found = contains(bubo, bucket, pt);
+        found = contains(bubo, bucket, point);
         expect(found).equal(true);
     });
 
     it('delete: removes a specified point', function() {
         var bubo = new Bubo(options);
-
-        var pt = {
-            name: 'cpu.system',
-            pop: 'SF',
-            host: 'foo.com',
-            time: new Date(),
-            time2: new Date(),
-            value: 100,
-            value2: 100,
-            value3: 100.999,
-            source_type: 'metric',
-        };
-
         var bucket = 'delete_test';
 
-        add(bubo, bucket, pt);
+        add(bubo, bucket, point);
 
-        expect(contains(bubo, bucket, pt)).equal(true);
+        expect(contains(bubo, bucket, point)).equal(true);
 
-        bubo.delete('delete_test', pt);
+        bubo.delete('delete_test', point);
 
-        expect(contains(bubo, bucket, pt)).equal(false);
+        expect(contains(bubo, bucket, point)).equal(false);
     });
 
     it('get_buckets', function() {
         var bubo = new Bubo(options);
-
         var initial_buckets = bubo.get_buckets();
-        expect(initial_buckets).deep.equal([]);
 
-        var pt = {
-            name: 'cpu.system',
-            pop: 'SF',
-            host: 'foo.com',
-            time: new Date(),
-            time2: new Date(),
-            value: 100,
-            value2: 100,
-            value3: 100.999,
-            source_type: 'metric',
-        };
+        expect(initial_buckets).deep.equal([]);
 
         var bucket1 = 'bucket1';
         var bucket2 = 'bucket2';
         var bucket3 = 'bucket3';
 
-        add(bubo, bucket1, pt);
-        add(bubo, bucket2, pt);
-        add(bubo, bucket3, pt);
+        add(bubo, bucket1, point);
+        add(bubo, bucket2, point);
+        add(bubo, bucket3, point);
 
         var buckets = bubo.get_buckets().sort();
 
@@ -198,27 +161,14 @@ describe('bubo', function() {
 
     it('handles delete_bucket correctly', function() {
         var bubo = new Bubo(options);
-
-        var pt = {
-            name: 'cpu.system',
-            pop: 'SF',
-            host: 'foo.com',
-            time: new Date(),
-            time2: new Date(),
-            value: 100,
-            value2: 100,
-            value3: 100.999,
-            source_type: 'metric',
-        };
-
         var bucket = 'delete_this_bucket';
 
-        var found = add(bubo, bucket, pt);
+        var found = add(bubo, bucket, point);
         expect(found).to.be.false;
-        expect(contains(bubo, bucket, pt)).equal(true);
+        expect(contains(bubo, bucket, point)).equal(true);
 
         bubo.delete_bucket(bucket);
-        expect(contains(bubo, bucket, pt)).equal(false);
+        expect(contains(bubo, bucket, point)).equal(false);
     });
 
     it('returns appropriate stats', function() {
@@ -234,20 +184,7 @@ describe('bubo', function() {
         bubo.stats(s1);
         expect(s1.strings_table.num_tags).equal(0);
 
-        // [1]
-        var pt = {
-            name: 'cpu.system',
-            pop: 'SF',
-            host: 'foo.com',
-            time: new Date(),
-            time2: new Date(),
-            value: 100,
-            value2: 100,
-            value3: 100.999,
-            source_type: 'metric'
-        };
-
-        var found = add(bubo, 'spc@bkt', pt);
+        var found = add(bubo, 'spc@bkt', point);
         s1 = {};
         bubo.stats(s1);
 
@@ -257,12 +194,11 @@ describe('bubo', function() {
         expect(s1['spc@bkt'].blob_allocated_bytes).equal(20971520); //20MB default size
         expect(s1['spc@bkt'].blob_used_bytes).equal(13); // 1 byte for size, 6 x 2 bytes since all small numbers.
 
-        // [2] another point that reuses some strings.
-        pt = {
+        var point2 = {
             name: 'apple',
             pop: 'NY',
         };
-        found = add(bubo, 'spc@bkt', pt);
+        found = add(bubo, 'spc@bkt', point2);
         s1 = {};
         bubo.stats(s1);
 
@@ -276,18 +212,6 @@ describe('bubo', function() {
 
     it('has an ignoredAttributes per Bubo', function() {
         var bucket = 'ignored_attributes_bucket';
-        var pt = {
-            name: 'cpu.system',
-            pop: 'SF',
-            host: 'foo.com',
-            time: new Date(),
-            time2: new Date(),
-            value: 100,
-            value2: 100,
-            value3: 100.999,
-            source_type: 'metric',
-        };
-
         var ignoredAttributes1 = {
             time: true
         };
@@ -306,12 +230,12 @@ describe('bubo', function() {
             ignoredAttributes: ignoredAttributes2
         });
 
-        var expected1 = getAttributeString(pt, ignoredAttributes1);
-        add(bubo1, bucket, pt);
+        var expected1 = getAttributeString(point, ignoredAttributes1);
+        add(bubo1, bucket, point);
         expect(result.attr_str).equal(expected1);
 
-        var expected2 = getAttributeString(pt, ignoredAttributes2);
-        add(bubo2, bucket, pt);
+        var expected2 = getAttributeString(point, ignoredAttributes2);
+        add(bubo2, bucket, point);
         expect(result.attr_str).equal(expected2);
     });
 

--- a/test/bubo.spec.js
+++ b/test/bubo.spec.js
@@ -139,6 +139,32 @@ describe('bubo', function() {
         expect(found).equal(true);
     });
 
+    it('delete: removes a specified point', function() {
+        var bubo = new Bubo(options);
+
+        var pt = {
+            name: 'cpu.system',
+            pop: 'SF',
+            host: 'foo.com',
+            time: new Date(),
+            time2: new Date(),
+            value: 100,
+            value2: 100,
+            value3: 100.999,
+            source_type: 'metric',
+        };
+
+        var bucket = 'delete_test';
+
+        add(bubo, bucket, pt);
+
+        expect(contains(bubo, bucket, pt)).equal(true);
+
+        bubo.delete('delete_test', pt);
+
+        expect(contains(bubo, bucket, pt)).equal(false);
+    });
+
     it('handles remove_bucket correctly', function() {
         var bubo = new Bubo(options);
 

--- a/test/bubo.spec.js
+++ b/test/bubo.spec.js
@@ -30,6 +30,10 @@ function add(bubo, bucket, point) {
     return bubo.add(bucket, point, result);
 }
 
+function contains(bubo, bucket, point) {
+    return bubo.contains(bucket, point);
+}
+
 var options = {}
 
 describe('bubo', function() {
@@ -101,6 +105,38 @@ describe('bubo', function() {
         expect(result.attr_str).not.equal(expected);
         expect(found).to.be.false;
 
+    });
+
+    it('contains: checks if a point has been added without adding it', function() {
+        var bubo = new Bubo(options);
+        var bucket = 'contains_bucket';
+
+        var pt = {
+            name: 'cpu.system',
+            pop: 'SF',
+            host: 'foo.com',
+            time: new Date(),
+            time2: new Date(),
+            value: 100,
+            value2: 100,
+            value3: 100.999,
+            source_type: 'metric',
+        };
+
+        var found = contains(bubo, bucket, pt);
+        expect(found).equal(false);
+
+        found = contains(bubo, bucket, pt);
+        expect(found).equal(false);
+
+        found = add(bubo, bucket, pt);
+        expect(found).equal(false);
+
+        found = contains(bubo, bucket, pt);
+        expect(found).equal(true);
+
+        found = contains(bubo, bucket, pt);
+        expect(found).equal(true);
     });
 
     it('handles remove_bucket correctly', function() {

--- a/test/bubo.spec.js
+++ b/test/bubo.spec.js
@@ -165,6 +165,37 @@ describe('bubo', function() {
         expect(contains(bubo, bucket, pt)).equal(false);
     });
 
+    it('get_buckets', function() {
+        var bubo = new Bubo(options);
+
+        var initial_buckets = bubo.get_buckets();
+        expect(initial_buckets).deep.equal([]);
+
+        var pt = {
+            name: 'cpu.system',
+            pop: 'SF',
+            host: 'foo.com',
+            time: new Date(),
+            time2: new Date(),
+            value: 100,
+            value2: 100,
+            value3: 100.999,
+            source_type: 'metric',
+        };
+
+        var bucket1 = 'bucket1';
+        var bucket2 = 'bucket2';
+        var bucket3 = 'bucket3';
+
+        add(bubo, bucket1, pt);
+        add(bubo, bucket2, pt);
+        add(bubo, bucket3, pt);
+
+        var buckets = bubo.get_buckets().sort();
+
+        expect(buckets).deep.equal([bucket1, bucket2, bucket3]);
+    });
+
     it('handles delete_bucket correctly', function() {
         var bubo = new Bubo(options);
 

--- a/test/bubo.spec.js
+++ b/test/bubo.spec.js
@@ -107,6 +107,14 @@ describe('bubo', function() {
 
     });
 
+    it('add without result works', function() {
+        var bubo = new Bubo(options);
+        var bucket = 'add_no_result_test';
+        bubo.add(bucket, point);
+
+        expect(bubo.contains(bucket, point)).equal(true);
+    });
+
     it('contains: checks if a point has been added without adding it', function() {
         var bubo = new Bubo(options);
         var bucket = 'contains_bucket';


### PR DESCRIPTION
Remove a relic of an earlier implementation in which the bucket key used to be
a combination of two strings wrapped in a struct but now just wraps a single
string. Instead just use a std::string as the key.

Also rename `spaceBucket` to `bucket`.
