### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+
+sudo: required
+
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8
+
+before_install:
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8
+
+script:
+    - mocha


### PR DESCRIPTION
I had to do all kinds of black magic due to https://github.com/travis-ci/travis-ci/issues/1379 -- the default g++ you get from Travis is 4.6 which doesn't know about `-std=c++11`.

@demmer 
