### PR TITLE
Make ignored attributes an array

### DIFF
--- a/src/attrs-table.cc
+++ b/src/attrs-table.cc
@@ -10,7 +10,7 @@ static EntryToken* entryTokens[100];
 static const int MAX_BUFFER_SIZE = 16 << 10;
 
 AttributesTable::AttributesTable(StringsTable* strings_table,
-                                 Nan::Persistent<v8::Object>* ignored_attributes)
+                                 std::vector<std::string> ignored_attributes)
     : attributes_hash_set_(),
       strings_table_(strings_table),
       ignored_attributes_(ignored_attributes)
@@ -70,6 +70,10 @@ char* mystrcat( char* dest, const char* src, int* total_buffer_size ) {
      return --dest;
 }
 
+inline bool _contains(std::vector<std::string> vector, std::string string) {
+    return std::find(vector.begin(), vector.end(), string) != vector.end();
+}
+
 /* Returns true if all the tags and tag-names are found in the internal maps */
 bool AttributesTable::prepare_entry_buffer(const v8::Local<v8::Object>& pt,
                                            int* entry_len,
@@ -88,11 +92,13 @@ bool AttributesTable::prepare_entry_buffer(const v8::Local<v8::Object>& pt,
     for (u_int32_t i = 0; i < length; ++i) {
         v8::Local<v8::Value> key = Nan::Get(keys, i).ToLocalChecked();
         v8::Local<v8::String> key_str(key->ToString());
-        if (!ignored_attributes_->IsEmpty() && Nan::HasOwnProperty(Nan::New(*ignored_attributes_), key_str).FromJust()) {
+        v8::String::Utf8Value tag(key);
+        std::string tag_str(*tag);
+
+        if (!ignored_attributes_.empty() && _contains(ignored_attributes_, tag_str)) {
             continue;
         }
 
-        v8::String::Utf8Value tag(key);
         v8::String::Utf8Value val(Nan::Get(pt, key_str).ToLocalChecked());
 
         EntryToken* et = entryTokens[i];

--- a/src/attrs-table.cc
+++ b/src/attrs-table.cc
@@ -10,7 +10,7 @@ static EntryToken* entryTokens[100];
 static const int MAX_BUFFER_SIZE = 16 << 10;
 
 AttributesTable::AttributesTable(StringsTable* strings_table,
-                                 std::vector<std::string> ignored_attributes)
+                                 std::vector<std::string> *ignored_attributes)
     : attributes_hash_set_(),
       strings_table_(strings_table),
       ignored_attributes_(ignored_attributes)
@@ -70,8 +70,8 @@ char* mystrcat( char* dest, const char* src, int* total_buffer_size ) {
      return --dest;
 }
 
-inline bool _contains(std::vector<std::string> vector, std::string string) {
-    return std::find(vector.begin(), vector.end(), string) != vector.end();
+inline bool _contains(std::vector<std::string> *vector, std::string string) {
+    return std::find(vector->begin(), vector->end(), string) != vector->end();
 }
 
 /* Returns true if all the tags and tag-names are found in the internal maps */
@@ -95,7 +95,7 @@ bool AttributesTable::prepare_entry_buffer(const v8::Local<v8::Object>& pt,
         v8::String::Utf8Value tag(key);
         std::string tag_str(*tag);
 
-        if (!ignored_attributes_.empty() && _contains(ignored_attributes_, tag_str)) {
+        if (ignored_attributes_ != NULL && _contains(ignored_attributes_, tag_str)) {
             continue;
         }
 

--- a/src/attrs-table.h
+++ b/src/attrs-table.h
@@ -11,7 +11,7 @@ class StringsTable;
 
 class AttributesTable {
 public:
-	AttributesTable(StringsTable* strings_table, std::vector<std::string> ignored_attributes);
+	AttributesTable(StringsTable* strings_table, std::vector<std::string> *ignored_attributes);
     virtual ~AttributesTable();
 
 	bool add(const v8::Local<v8::Object>& pt, bool should_get_attr_str, v8::Local<v8::String>& attr_str, int* error);
@@ -51,7 +51,7 @@ public:
 protected:
 	BuboHashSet<BytePtrHash, BytePtrEqual> attributes_hash_set_;
 	StringsTable* strings_table_;
-	std::vector<std::string> ignored_attributes_;
+	std::vector<std::string>* ignored_attributes_ = NULL;
 
 	BYTE entry_buf_[16 << 10] __attribute__ ((aligned (8)));
 };

--- a/src/attrs-table.h
+++ b/src/attrs-table.h
@@ -11,7 +11,7 @@ class StringsTable;
 
 class AttributesTable {
 public:
-	AttributesTable(StringsTable* strings_table, Nan::Persistent<v8::Object>* ignored_attributes);
+	AttributesTable(StringsTable* strings_table, std::vector<std::string> ignored_attributes);
     virtual ~AttributesTable();
 
 	bool add(const v8::Local<v8::Object>& pt, bool should_get_attr_str, v8::Local<v8::String>& attr_str, int* error);
@@ -51,7 +51,7 @@ public:
 protected:
 	BuboHashSet<BytePtrHash, BytePtrEqual> attributes_hash_set_;
 	StringsTable* strings_table_;
-	Nan::Persistent<v8::Object>* ignored_attributes_;
+	std::vector<std::string> ignored_attributes_;
 
 	BYTE entry_buf_[16 << 10] __attribute__ ((aligned (8)));
 };

--- a/src/bubo-cache.cc
+++ b/src/bubo-cache.cc
@@ -23,7 +23,7 @@ BuboCache::~BuboCache() {
     delete strings_table_;
 }
 
-void BuboCache::initialize(std::vector<std::string> ignoredAttrs) {
+void BuboCache::initialize(const std::vector<std::string>& ignoredAttrs) {
     ignored_attributes_ = ignoredAttrs;
 }
 
@@ -36,7 +36,7 @@ bool BuboCache::add(const v8::Local<v8::String>& bucket,
     AttributesTable* at = NULL;
     bubo_cache_t::iterator it = bubo_cache_.find(key);
     if (it == bubo_cache_.end()) {
-        at = new AttributesTable(strings_table_, ignored_attributes_);
+        at = new AttributesTable(strings_table_, &ignored_attributes_);
         bubo_cache_.insert(std::make_pair(key, at));
     } else {
         at = it->second;

--- a/src/bubo-cache.cc
+++ b/src/bubo-cache.cc
@@ -23,8 +23,8 @@ BuboCache::~BuboCache() {
     delete strings_table_;
 }
 
-void BuboCache::initialize(v8::Local<v8::Object> ignoredAttrs) {
-    ignored_attributes_.Reset(ignoredAttrs);
+void BuboCache::initialize(std::vector<std::string> ignoredAttrs) {
+    ignored_attributes_ = ignoredAttrs;
 }
 
 bool BuboCache::add(const v8::Local<v8::String>& bucket,
@@ -36,7 +36,7 @@ bool BuboCache::add(const v8::Local<v8::String>& bucket,
     AttributesTable* at = NULL;
     bubo_cache_t::iterator it = bubo_cache_.find(key);
     if (it == bubo_cache_.end()) {
-        at = new AttributesTable(strings_table_, &ignored_attributes_);
+        at = new AttributesTable(strings_table_, ignored_attributes_);
         bubo_cache_.insert(std::make_pair(key, at));
     } else {
         at = it->second;

--- a/src/bubo-cache.h
+++ b/src/bubo-cache.h
@@ -14,7 +14,7 @@ public:
     BuboCache();
     virtual ~BuboCache();
 
-    void initialize(v8::Local<v8::Object> ignoredAttrs);
+    void initialize(std::vector<std::string> ignoredAttrs);
 
     bool add(const v8::Local<v8::String>& bucket,
                 const v8::Local<v8::Object>& pt,
@@ -39,5 +39,5 @@ protected:
     typedef std::unordered_map<std::string, AttributesTable*> bubo_cache_t;
     bubo_cache_t bubo_cache_;
     StringsTable* strings_table_;
-    Nan::Persistent<v8::Object> ignored_attributes_;
+    std::vector<std::string> ignored_attributes_;
 };

--- a/src/bubo-cache.h
+++ b/src/bubo-cache.h
@@ -14,7 +14,7 @@ public:
     BuboCache();
     virtual ~BuboCache();
 
-    void initialize(std::vector<std::string> ignoredAttrs);
+    void initialize(const std::vector<std::string>& ignoredAttrs);
 
     bool add(const v8::Local<v8::String>& bucket,
                 const v8::Local<v8::Object>& pt,

--- a/src/bubo.cc
+++ b/src/bubo.cc
@@ -55,8 +55,19 @@ NAN_METHOD(Bubo::Initialize)
         return;
     }
 
-    Local<Value> ignoredVal = Nan::Get(opts, ignoredAttributes).ToLocalChecked();
-    Local<Object> ignored = Nan::To<Object>(ignoredVal).ToLocalChecked();
+    Local<Value> ignored_value = Nan::Get(opts, ignoredAttributes).ToLocalChecked();
+    Local<Object> ignored_array = Nan::To<Object>(ignored_value).ToLocalChecked();
+    std::vector<std::string> ignored;
+    uint32_t i = 0;
+    v8::Local<v8::Value> ignored_value_string = Nan::Get(ignored_array, i).ToLocalChecked();
+    while (!ignored_value_string->IsUndefined()) {
+        v8::Local<v8::String> ignored_string(ignored_value_string->ToString());
+        v8::String::Utf8Value ignored_utf8_value(ignored_string);
+        std::string ignored_std_str(*ignored_utf8_value);
+
+        ignored.push_back(ignored_std_str);
+        ignored_value_string = Nan::Get(ignored_array, ++i).ToLocalChecked();
+    }
 
     cache_.initialize(ignored);
 }

--- a/src/bubo.cc
+++ b/src/bubo.cc
@@ -15,7 +15,7 @@ NAN_METHOD(NewInstance) {
     const unsigned argc = 1;
     Local<Value> argv[argc] = {info[0]};
     Local<Function> cons = Nan::New<Function>(Bubo::constructor);
-    MaybeLocal<Object> instance = Nan::NewInstance(cons, argc, argv);
+    Nan::MaybeLocal<Object> instance = Nan::NewInstance(cons, argc, argv);
 
     if (! instance.IsEmpty()) {
         info.GetReturnValue().Set(instance.ToLocalChecked());

--- a/src/test.cc
+++ b/src/test.cc
@@ -290,7 +290,7 @@ static void test_strings_table_sizes() {
 static void test_strings_table_entry_buf_basic() {
     // tests if basic functionality of prepare_entry_buffer() is allright.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
 
     v8::Local<v8::Object> pt = Nan::New<v8::Object>();
     Nan::Set(pt, Nan::New("proxy").ToLocalChecked(), Nan::New("sfdc1").ToLocalChecked());              // tag seq 1 -> position 3 sorted.
@@ -326,7 +326,7 @@ static void test_strings_table_entry_buf_basic() {
 static void test_strings_table_entry_buf_repeated() {
     // tests if functionality of prepare_entry_buffer() is allright when things repeat.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
 
     int buflen = 0;
 
@@ -372,7 +372,7 @@ static void test_strings_table_entry_buf_repeated() {
 static void test_strings_table_entry_buf_large_seq() {
     // Test for sequence numbers larger than 127 (these will require more than 1 byte)
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
 
     v8::Local<v8::String> tbase = Nan::New("mytag").ToLocalChecked();
     v8::Local<v8::String> vbase = Nan::New("myval").ToLocalChecked();
@@ -422,7 +422,7 @@ static void test_strings_table_entry_buf_large_seq() {
 void test_strings_table_wide_point() {
     // tests if prepare_entry_buffer() works with relatively wide inputs.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
 
     BYTE* buf = NULL;
     int buflen = 0;

--- a/src/test.cc
+++ b/src/test.cc
@@ -9,7 +9,7 @@
 #include "attrs-table.h"
 #include "bubo-ht.h"
 
-static Nan::Persistent<v8::Object> ignored_attributes;
+static std::vector<std::string> ignored_attributes;
 
 static void test_hash_function_same_input() {
     BYTE a[5];
@@ -290,7 +290,7 @@ static void test_strings_table_sizes() {
 static void test_strings_table_entry_buf_basic() {
     // tests if basic functionality of prepare_entry_buffer() is allright.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, ignored_attributes);
 
     v8::Local<v8::Object> pt = Nan::New<v8::Object>();
     Nan::Set(pt, Nan::New("proxy").ToLocalChecked(), Nan::New("sfdc1").ToLocalChecked());              // tag seq 1 -> position 3 sorted.
@@ -326,7 +326,7 @@ static void test_strings_table_entry_buf_basic() {
 static void test_strings_table_entry_buf_repeated() {
     // tests if functionality of prepare_entry_buffer() is allright when things repeat.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, ignored_attributes);
 
     int buflen = 0;
 
@@ -372,7 +372,7 @@ static void test_strings_table_entry_buf_repeated() {
 static void test_strings_table_entry_buf_large_seq() {
     // Test for sequence numbers larger than 127 (these will require more than 1 byte)
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, ignored_attributes);
 
     v8::Local<v8::String> tbase = Nan::New("mytag").ToLocalChecked();
     v8::Local<v8::String> vbase = Nan::New("myval").ToLocalChecked();
@@ -422,7 +422,7 @@ static void test_strings_table_entry_buf_large_seq() {
 void test_strings_table_wide_point() {
     // tests if prepare_entry_buffer() works with relatively wide inputs.
     StringsTable* st = new StringsTable();
-    AttributesTable* at = new AttributesTable(st, &ignored_attributes);
+    AttributesTable* at = new AttributesTable(st, ignored_attributes);
 
     BYTE* buf = NULL;
     int buflen = 0;

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,7 +19,7 @@ struct EntryToken {
 
 namespace bubo_utils {
 
-void initialize(v8::Local<v8::Object> ignoredAttrs);
+void initialize(std::vector<std::string> ignoredAttrs);
 
 void hex_out(const BYTE* data, int len, const char* hint=NULL);
 

--- a/test/bubo.spec.js
+++ b/test/bubo.spec.js
@@ -4,10 +4,10 @@ var expect = require('chai').expect;
 var util = require('util');
 
 function getAttributeString(point, ignoredAttributes) {
-    ignoredAttributes = ignoredAttributes || {};
+    ignoredAttributes = ignoredAttributes || [];
     var keys = [];
     _.each(point, function(val, key) {
-        if (!ignoredAttributes[key]) {
+        if (!_.contains(ignoredAttributes, key)) {
             keys.push(key);
         }
     });
@@ -181,11 +181,7 @@ describe('bubo', function() {
 
     it('returns appropriate stats', function() {
         var bubo = new Bubo({
-            ignoredAttributes: {
-                time: true,
-                value: true,
-                source_type: true
-            }
+            ignoredAttributes: ['time', 'value', 'source_type']
         });
 
         var s1 = {};
@@ -220,15 +216,9 @@ describe('bubo', function() {
 
     it('has an ignoredAttributes per Bubo', function() {
         var bucket = 'ignored_attributes_bucket';
-        var ignoredAttributes1 = {
-            time: true
-        };
+        var ignoredAttributes1 = ['time'];
 
-        var ignoredAttributes2 = {
-            time: true,
-            pop: true,
-            name: true
-        };
+        var ignoredAttributes2 = ['time', 'pop', 'name'];
 
         var bubo1 = new Bubo({
             ignoredAttributes: ignoredAttributes1

--- a/test/bubo.spec.js
+++ b/test/bubo.spec.js
@@ -237,6 +237,13 @@ describe('bubo', function() {
         expect(result.attr_str).equal(expected2);
     });
 
+    it('rejects ignoredAttributes that is not an array', function() {
+        expect(function() { return new Bubo({ignoredAttributes: []}); }).to.not.throw(Error);
+        expect(function() { return new Bubo({ignoredAttributes: 1}); }).to.throw(Error);
+        expect(function() { return new Bubo({ignoredAttributes: "ignoreme"}); }).to.throw(Error);
+        expect(function() { return new Bubo({ignoredAttributes: {}}); }).to.throw(Error);
+    });
+
     it.skip('profiles the memory use of adding 7 million points', function() {
         this.timeout(900000);
         var bubo = new Bubo(options);


### PR DESCRIPTION
Currently you initialize Bubo's ignored attributes as an object whose keys are the attributes you want to ignore. This is weird. It should just be an array of the attributes you want to ignore. And then the `ignored_attributes` all over the Bubo code are `std::vector`s instead of v8 objects. This didn't noticeably change performance.

@demmer 
